### PR TITLE
Remove deprecated packages from packages.config

### DIFF
--- a/windows/chocolatey/packages.config
+++ b/windows/chocolatey/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="7zip.install" />
   <package id="amd-ryzen-chipset" />
-  <package id="atom" />
   <package id="audacity" />
   <package id="autohotkey.portable" />
   <package id="brave" />
@@ -55,8 +54,6 @@
   <package id="putty" />
   <package id="putty.portable" />
   <package id="python3" />
-  <package id="python311" />
-  <package id="python312" />
   <package id="python313" />
   <package id="python314" />
   <package id="qbittorrent" />


### PR DESCRIPTION
Removed 'atom', 'python311', and 'python312' packages from the configuration.